### PR TITLE
Restore PR bypass rules for select committers

### DIFF
--- a/otterdog/jetty.jsonnet
+++ b/otterdog/jetty.jsonnet
@@ -131,6 +131,12 @@ orgs.newOrg('jetty') {
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('jetty-9.4.x') {
+          bypass_pull_request_allowances+: [
+            "@gregw",
+            "@janbartel",
+            "@sbordet",
+            "@joakime"
+          ],
           dismisses_stale_reviews: true,
           required_approving_review_count: 1,
           required_status_checks+: [
@@ -138,6 +144,12 @@ orgs.newOrg('jetty') {
           ],
         },
         orgs.newBranchProtectionRule('jetty-10.0.x') {
+          bypass_pull_request_allowances+: [
+            "@gregw",
+            "@janbartel",
+            "@sbordet",
+            "@joakime"
+          ],
           dismisses_stale_reviews: true,
           required_approving_review_count: 1,
           required_status_checks+: [
@@ -145,6 +157,12 @@ orgs.newOrg('jetty') {
           ],
         },
         orgs.newBranchProtectionRule('jetty-12.0.x') {
+          bypass_pull_request_allowances+: [
+            "@gregw",
+            "@janbartel",
+            "@sbordet",
+            "@joakime"
+          ],
           required_approving_review_count: 1,
         },
       ],

--- a/otterdog/jetty.jsonnet
+++ b/otterdog/jetty.jsonnet
@@ -138,10 +138,6 @@ orgs.newOrg('jetty') {
             "@joakime"
           ],
           dismisses_stale_reviews: true,
-          push_restrictions+: [
-            "@gregw",
-            "@sbordet"
-          ],
           required_approving_review_count: 1,
           required_status_checks+: [
             "any:continuous-integration/jenkins/pr-merge",
@@ -155,10 +151,6 @@ orgs.newOrg('jetty') {
             "@joakime"
           ],
           dismisses_stale_reviews: true,
-          push_restrictions+: [
-            "@gregw",
-            "@sbordet"
-          ],
           required_approving_review_count: 1,
           required_status_checks+: [
             "any:continuous-integration/jenkins/pr-merge",
@@ -170,10 +162,6 @@ orgs.newOrg('jetty') {
             "@janbartel",
             "@sbordet",
             "@joakime"
-          ],
-          push_restrictions+: [
-            "@gregw",
-            "@sbordet"
           ],
           required_approving_review_count: 1,
         },

--- a/otterdog/jetty.jsonnet
+++ b/otterdog/jetty.jsonnet
@@ -138,6 +138,10 @@ orgs.newOrg('jetty') {
             "@joakime"
           ],
           dismisses_stale_reviews: true,
+          push_restrictions+: [
+            "@gregw",
+            "@sbordet"
+          ],
           required_approving_review_count: 1,
           required_status_checks+: [
             "any:continuous-integration/jenkins/pr-merge",
@@ -151,6 +155,10 @@ orgs.newOrg('jetty') {
             "@joakime"
           ],
           dismisses_stale_reviews: true,
+          push_restrictions+: [
+            "@gregw",
+            "@sbordet"
+          ],
           required_approving_review_count: 1,
           required_status_checks+: [
             "any:continuous-integration/jenkins/pr-merge",
@@ -162,6 +170,10 @@ orgs.newOrg('jetty') {
             "@janbartel",
             "@sbordet",
             "@joakime"
+          ],
+          push_restrictions+: [
+            "@gregw",
+            "@sbordet"
           ],
           required_approving_review_count: 1,
         },


### PR DESCRIPTION
This restores previous functionality to allow commit bypass of PRs to select committers.

This was used to get past CI or CodeQL issues, never ECA.

The push_restrictions additions allows for traditional merge between branches without the need for a PR