### PR TITLE
Adding new schema repos

### DIFF
--- a/otterdog/jetty.jsonnet
+++ b/otterdog/jetty.jsonnet
@@ -219,5 +219,31 @@ orgs.newOrg('jetty') {
         actions_can_approve_pull_request_reviews: false,
       },
     },
+    orgs.newRepo('jetty.schemas') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      default_branch: "main",
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      description: "Eclipse Jetty® - General Schemas Jar",
+      homepage: "http://eclipse.org/jetty",
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+    },
+    orgs.newRepo('jetty.schemas.xhtml') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      default_branch: "main",
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      description: "Eclipse Jetty® - XHTML Schemas Jar",
+      homepage: "http://eclipse.org/jetty",
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+    },
   ],
 }


### PR DESCRIPTION
 + jetty.schemas - for general schemas (like servlet + jsp) across jetty versions
 + jetty.schemas.xhtml - for XHTML specific schemas used during tests in various Jetty projects.