### PR TITLE
New default branch on jetty-example

### DIFF
--- a/otterdog/jetty.jsonnet
+++ b/otterdog/jetty.jsonnet
@@ -85,7 +85,7 @@ orgs.newOrg('rt.jetty', 'jetty') {
     },
     orgs.newRepo('jetty-examples') {
       allow_merge_commit: true,
-      default_branch: "12.0.x",
+      default_branch: "12.1.x",
       dependabot_security_updates_enabled: true,
       description: "Eclipse Jetty® - Examples",
       homepage: "https://jetty.org/",


### PR DESCRIPTION
* Changing default branch on jetty/jetty-examples to 12.1.x