### PR TITLE
Restore temporary branches 9.4.x, 10.0.x and 11.0.x

### DIFF
--- a/otterdog/jetty.jsonnet
+++ b/otterdog/jetty.jsonnet
@@ -311,6 +311,9 @@ orgs.newOrg('rt.jetty', 'jetty') {
             "@jetty/rt-jetty-pmc"
           ],
           include_refs+: [
+            "refs/heads/jetty-9.4.x",
+            "refs/heads/jetty-10.0.x",
+            "refs/heads/jetty-11.0.x",
             "refs/heads/jetty-12.0.x",
             "refs/heads/jetty-12.1.x"
           ],
@@ -323,15 +326,6 @@ orgs.newOrg('rt.jetty', 'jetty') {
               "continuous-integration/jenkins/pr-merge"
             ],
           },
-        },
-        orgs.newRepoRuleset('read-only-branches') {
-          allows_updates: false,
-          allows_deletions: false,
-          include_refs+: [
-            "refs/heads/jetty-9.4.x",
-            "refs/heads/jetty-10.0.x",
-            "refs/heads/jetty-11.0.x"
-          ],
         },
       ],
     },

--- a/otterdog/jetty.jsonnet
+++ b/otterdog/jetty.jsonnet
@@ -327,6 +327,16 @@ orgs.newOrg('rt.jetty', 'jetty') {
             ],
           },
         },
+        orgs.newRepoRuleset('read-only-branches') {
+          enforcement: "disabled",
+          allows_updates: false,
+          allows_deletions: false,
+          include_refs+: [
+            "refs/heads/jetty-9.4.x",
+            "refs/heads/jetty-10.0.x",
+            "refs/heads/jetty-11.0.x"
+          ],
+        },
       ],
     },
     orgs.newRepo('jetty.website') {


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
